### PR TITLE
Initialize main scene

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,5 +11,6 @@ config_version=5
 [application]
 
 config/name="2D-shooter-rogue-like"
+run/main_scene="res://scenes/main.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,0 +1,11 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	print("hello godot!")
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://cfxky3wsmddss"]
+
+[ext_resource type="Script" path="res://scenes/main.gd" id="1_crwy1"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1_crwy1")


### PR DESCRIPTION
I added a scene, and set it to be the main scene that runs on startup.

We haven't discussed the project structure yet, so I put both the scene and script in the `./scenes` folder. I believe we should have a folder for each game entity that contains its scene, script(s), and assets (e.g a `./player` folder).
