### PR TITLE
Add Functional Main Menu

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="2D-shooter-rogue-like"
-run/main_scene="res://scenes/main.tscn"
+run/main_scene="res://scenes/main_menu.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/scenes/level.gd
+++ b/scenes/level.gd
@@ -1,0 +1,11 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	print("hello godot!")
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/scenes/level.tscn
+++ b/scenes/level.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=6 format=3 uid="uid://cfxky3wsmddss"]
+
+[ext_resource type="Script" path="res://scenes/level.gd" id="1_0wm6v"]
+[ext_resource type="PackedScene" uid="uid://olh5bqt5tvrl" path="res://scenes/platform.tscn" id="2_g5rv4"]
+[ext_resource type="PackedScene" uid="uid://fra6qckawjji" path="res://player/player.tscn" id="3_mirjn"]
+[ext_resource type="PackedScene" uid="uid://barsmnu577o5u" path="res://enemies/flying_boss/boss1.tscn" id="4_e3ibo"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_sx256"]
+size = Vector2(639, 40)
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1_0wm6v")
+
+[node name="Ground" type="StaticBody2D" parent="."]
+position = Vector2(0, 14)
+metadata/_edit_group_ = true
+
+[node name="ColorRect" type="ColorRect" parent="Ground"]
+offset_left = -1.0
+offset_top = 291.0
+offset_right = 638.0
+offset_bottom = 331.0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Ground"]
+position = Vector2(318.5, 311)
+shape = SubResource("RectangleShape2D_sx256")
+
+[node name="Platform" parent="." instance=ExtResource("2_g5rv4")]
+position = Vector2(246, 242)
+
+[node name="Player" parent="." instance=ExtResource("3_mirjn")]
+
+[node name="Boss1" parent="." instance=ExtResource("4_e3ibo")]
+position = Vector2(322, 49)

--- a/scenes/main_menu.gd
+++ b/scenes/main_menu.gd
@@ -1,0 +1,19 @@
+extends Control
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func _on_play_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/level.tscn")
+
+
+func _on_quit_pressed() -> void:
+	get_tree().quit()

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -1,0 +1,125 @@
+[gd_scene load_steps=6 format=3 uid="uid://d1tmp8ph7l35w"]
+
+[ext_resource type="Script" path="res://scenes/main_menu.gd" id="1_vgs2m"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rihxc"]
+bg_color = Color(0.174942, 0.381679, 0.428497, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7t1sb"]
+bg_color = Color(0.577008, 0.577008, 0.577008, 0.760784)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_i232d"]
+bg_color = Color(0.244776, 0.244776, 0.244776, 0.760784)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bns2b"]
+bg_color = Color(1, 1, 1, 0.760784)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 5
+
+[node name="MainMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_vgs2m")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_rihxc")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -151.5
+offset_top = -54.0
+offset_right = 151.5
+offset_bottom = 137.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 30
+
+[node name="Play Game Button" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 48
+theme_override_styles/hover = SubResource("StyleBoxFlat_7t1sb")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_i232d")
+theme_override_styles/normal = SubResource("StyleBoxFlat_bns2b")
+text = "Play Game"
+
+[node name="Quit Button" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 48
+theme_override_styles/hover = SubResource("StyleBoxFlat_7t1sb")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_i232d")
+theme_override_styles/normal = SubResource("StyleBoxFlat_bns2b")
+text = "Quit"
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -283.0
+offset_top = -145.0
+offset_right = 283.0
+offset_bottom = -74.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 48
+text = "Game Title (Placeholder)"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[connection signal="pressed" from="VBoxContainer/Play Game Button" to="." method="_on_play_pressed"]
+[connection signal="pressed" from="VBoxContainer/Quit Button" to="." method="_on_quit_pressed"]


### PR DESCRIPTION
Adds a main menu with a functioning button to start and quit the game. On my end, I set this as the main scene in Godot (the one that first plays upon start-up), and to avoid confusion I renamed main.gd and main.tscn to level.gd and level.tscn respectively. We'll need to make those same edits to the main branch for the main menu to work properly.