### PR TITLE
Economy Systems, Game Over, and Restart

### DIFF
--- a/equip_items.gd
+++ b/equip_items.gd
@@ -2,11 +2,16 @@ extends Node
 
 var weapon = 0
 var equipment = 0
+var bank = 1000
+var money = 0
+var cart = 0
+
+var w_prices = [200, 500]
+var e_prices = [200, 500]
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	print(weapon, equipment)
-
+	pass
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
@@ -14,8 +19,20 @@ func _process(delta: float) -> void:
 
 func _equip_weapon(index: int):
 	weapon = index
-	print(weapon)
 	
 func _equip_equipment(index: int):
 	equipment = index
-	print(equipment)
+
+func _get_cart_() -> int:
+	cart = 0
+	if weapon != 0:
+		cart += e_prices[weapon-1]
+	if equipment != 0:
+		cart += e_prices[equipment-1]
+	return cart
+
+func _get_bank() -> int:
+	bank -= e_prices[weapon-1]
+	bank -= e_prices[equipment-1]
+	return bank
+	

--- a/player/player.gd
+++ b/player/player.gd
@@ -22,10 +22,10 @@ var weapon
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	if EquipItems.weapon == 0:
+	if EquipItems.weapon == 1:
 		WEAPON_LOAD = preload("res://weapons/Pistol.tscn")
 		
-	if EquipItems.weapon == 1:
+	if EquipItems.weapon == 2:
 		WEAPON_LOAD = preload("res://weapons/Sniper.tscn")
 	
 	weapon = WEAPON_LOAD.instantiate()
@@ -34,6 +34,7 @@ func _ready() -> void:
 	screen_size = get_viewport_rect().size
 
 	add_to_group("player") # for the HUD
+	print("Player has $" + str(EquipItems._get_bank()) + " in their Bank.")
 
 func _physics_process(delta: float) -> void:
 	# handle jumping
@@ -112,3 +113,8 @@ func start(pos):
 	position = pos
 	show()
 	$CollisionShape2D.disabled = false
+
+func _on_money_timer_timeout() -> void:
+	if HEALTH > 0:
+		EquipItems.money += 5
+		print(EquipItems.money)

--- a/player/player.gd
+++ b/player/player.gd
@@ -107,6 +107,9 @@ func _on_body_entered(body: Node2D) -> void:
 # called once whenever the player is hit by a bullet.
 # TODO: even though Ground is on a diff collision layer, the bullet still emits. fix
 func _on_bullet_hit() -> void:
+	HEALTH -= 50
+	if HEALTH == 0:
+		_on_death()
 	print("BULLET OW!!")
 	
 func start(pos):
@@ -118,3 +121,6 @@ func _on_money_timer_timeout() -> void:
 	if HEALTH > 0:
 		EquipItems.money += 5
 		print(EquipItems.money)
+		
+func _on_death() -> void:
+	get_tree().change_scene_to_file("res://scenes/game_over.tscn")

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -76,3 +76,8 @@ position = Vector2(0, 10.3333)
 [node name="CoyoteTimer" type="Timer" parent="."]
 wait_time = 0.1
 one_shot = true
+
+[node name="Money_Timer" type="Timer" parent="."]
+autostart = true
+
+[connection signal="timeout" from="Money_Timer" to="." method="_on_money_timer_timeout"]

--- a/scenes/game_over.gd
+++ b/scenes/game_over.gd
@@ -1,0 +1,27 @@
+extends Control
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func _on_restart_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+
+
+func _on_quit_pressed() -> void:
+	$Quit_Confirm.visible = true
+
+
+func _on_yes_pressed() -> void:
+	get_tree().quit()
+
+
+func _on_no_pressed() -> void:
+	$Quit_Confirm.visible = false

--- a/scenes/game_over.tscn
+++ b/scenes/game_over.tscn
@@ -1,0 +1,282 @@
+[gd_scene load_steps=11 format=3 uid="uid://fwwxmt2e06qi"]
+
+[ext_resource type="Script" path="res://scenes/game_over.gd" id="1_fpcu1"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_852nu"]
+bg_color = Color(0, 0, 0, 0.827451)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_khfcj"]
+bg_color = Color(0.577008, 0.577008, 0.577008, 0.760784)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gldtx"]
+bg_color = Color(0.244776, 0.244776, 0.244776, 0.760784)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vwf0o"]
+bg_color = Color(1, 1, 1, 0.760784)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_83b7e"]
+bg_color = Color(0, 0, 0, 0.635294)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_a3eeb"]
+bg_color = Color(0.251929, 0.508773, 0.568412, 1)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+shadow_color = Color(0, 0, 0, 0.843137)
+shadow_size = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_01ynf"]
+bg_color = Color(0.576471, 0.576471, 0.576471, 0.760784)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 3
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y1saq"]
+bg_color = Color(0.243137, 0.243137, 0.243137, 0.760784)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 3
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_eruu1"]
+bg_color = Color(1, 1, 1, 0.760784)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+shadow_size = 3
+
+[node name="GameOver" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_fpcu1")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_852nu")
+
+[node name="Label" type="Label" parent="Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -285.0
+offset_top = -153.0
+offset_right = 285.0
+offset_bottom = -16.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(1, 0, 0, 1)
+theme_override_font_sizes/font_size = 100
+text = "Game Over!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Restart" type="Button" parent="Panel"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -279.0
+offset_top = -155.0
+offset_right = -24.0
+offset_bottom = -78.0
+grow_horizontal = 2
+grow_vertical = 0
+size_flags_vertical = 3
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 48
+theme_override_styles/hover = SubResource("StyleBoxFlat_khfcj")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_gldtx")
+theme_override_styles/normal = SubResource("StyleBoxFlat_vwf0o")
+text = "Restart"
+
+[node name="Quit" type="Button" parent="Panel"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = 17.0
+offset_top = -155.0
+offset_right = 272.0
+offset_bottom = -78.0
+grow_horizontal = 2
+grow_vertical = 0
+size_flags_vertical = 3
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 48
+theme_override_styles/hover = SubResource("StyleBoxFlat_khfcj")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_gldtx")
+theme_override_styles/normal = SubResource("StyleBoxFlat_vwf0o")
+text = "Quit"
+
+[node name="Quit_Confirm" type="Control" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Panel2" type="Panel" parent="Quit_Confirm"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_83b7e")
+
+[node name="Panel" type="Panel" parent="Quit_Confirm"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -159.5
+offset_top = -83.0
+offset_right = 159.5
+offset_bottom = 83.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_a3eeb")
+
+[node name="Yes" type="Button" parent="Quit_Confirm"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -107.0
+offset_top = -2.0
+offset_right = -38.0
+offset_bottom = 40.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_styles/hover = SubResource("StyleBoxFlat_01ynf")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_y1saq")
+theme_override_styles/normal = SubResource("StyleBoxFlat_eruu1")
+text = "Yes"
+
+[node name="No" type="Button" parent="Quit_Confirm"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 41.0
+offset_top = -2.0
+offset_right = 110.0
+offset_bottom = 40.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_styles/hover = SubResource("StyleBoxFlat_01ynf")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_y1saq")
+theme_override_styles/normal = SubResource("StyleBoxFlat_eruu1")
+text = "No"
+
+[node name="Label" type="Label" parent="Quit_Confirm"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -149.0
+offset_top = -63.0
+offset_right = 149.0
+offset_bottom = -17.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 20
+text = "Are you sure you'd like to quit?"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[connection signal="pressed" from="Panel/Restart" to="." method="_on_restart_pressed"]
+[connection signal="pressed" from="Panel/Quit" to="." method="_on_quit_pressed"]
+[connection signal="pressed" from="Quit_Confirm/Yes" to="." method="_on_yes_pressed"]
+[connection signal="pressed" from="Quit_Confirm/No" to="." method="_on_no_pressed"]

--- a/scenes/shop.gd
+++ b/scenes/shop.gd
@@ -2,6 +2,9 @@ extends Control
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	EquipItems.weapon = 0
+	EquipItems.equipment = 0
+	EquipItems.cart = 0
 	get_node("Bank").text = "Bank: $" + str(EquipItems.bank)
 
 
@@ -10,11 +13,15 @@ func _process(delta: float) -> void:
 	pass
 
 func _on_confirm_pressed() -> void:
-	if (EquipItems.weapon != 0) and (EquipItems.equipment != 0):
-		$Select_Confirm.visible = true
-	else:
-		$Must_Select.visible = true
-		$Select_Confirm.visible = false
+	if EquipItems.cart > EquipItems.bank:
+		$Not_Enough.visible = true
+	
+	if EquipItems.cart <= EquipItems.bank:
+		if (EquipItems.weapon == 0) or (EquipItems.equipment == 0):
+			$Must_Select.visible = true
+			$Select_Confirm.visible = false
+		if (EquipItems.weapon != 0) and (EquipItems.equipment != 0):
+			$Select_Confirm.visible = true
 
 func _on_yes_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/level.tscn")
@@ -22,6 +29,9 @@ func _on_yes_pressed() -> void:
 
 func _on_okay_pressed() -> void:
 	$Must_Select.visible = false
+	
+func _on_okay_2_pressed() -> void:
+	$Not_Enough.visible = false
 
 func _on_no_pressed() -> void:
 	$Select_Confirm.visible = false

--- a/scenes/shop.gd
+++ b/scenes/shop.gd
@@ -2,7 +2,7 @@ extends Control
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	get_node("Bank").text = "Bank: $" + str(EquipItems.bank)
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -10,12 +10,18 @@ func _process(delta: float) -> void:
 	pass
 
 func _on_confirm_pressed() -> void:
-	$Select_Confirm.visible = true
-
+	if (EquipItems.weapon != 0) and (EquipItems.equipment != 0):
+		$Select_Confirm.visible = true
+	else:
+		$Must_Select.visible = true
+		$Select_Confirm.visible = false
 
 func _on_yes_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/level.tscn")
+	
 
+func _on_okay_pressed() -> void:
+	$Must_Select.visible = false
 
 func _on_no_pressed() -> void:
 	$Select_Confirm.visible = false
@@ -24,11 +30,13 @@ func _on_weapons_list_item_clicked(index: int, at_position: Vector2, mouse_butto
 	var weapons = ["Pistol", "Sniper Rifle"]
 	print("Player Selected: ", weapons[index])
 	
-	EquipItems._equip_weapon(index)
+	EquipItems._equip_weapon(index+1)
+	get_node("Cart").text = "-$" + str(EquipItems._get_cart_())
 
 
 func _on_equipment_list_item_clicked(index: int, at_position: Vector2, mouse_button_index: int) -> void:
 	var equipment = ["Double Jump", "Grapple Hook"]
 	print("Player Selected: ", equipment[index])
 	
-	EquipItems._equip_equipment(index)
+	EquipItems._equip_equipment(index+1)
+	get_node("Cart").text = "-$" + str(EquipItems._get_cart_())

--- a/scenes/shop.tscn
+++ b/scenes/shop.tscn
@@ -44,6 +44,19 @@ corner_radius_bottom_right = 30
 corner_radius_bottom_left = 30
 shadow_size = 3
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nwf7w"]
+bg_color = Color(0, 0, 0, 0.423529)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+border_blend = true
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5xvl3"]
 bg_color = Color(0, 0, 0, 0.635294)
 
@@ -95,19 +108,6 @@ corner_radius_top_right = 30
 corner_radius_bottom_right = 30
 corner_radius_bottom_left = 30
 shadow_size = 3
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nwf7w"]
-bg_color = Color(0, 0, 0, 0.423529)
-border_width_left = 5
-border_width_top = 5
-border_width_right = 5
-border_width_bottom = 5
-border_color = Color(0, 0, 0, 1)
-border_blend = true
-corner_radius_top_left = 30
-corner_radius_top_right = 30
-corner_radius_bottom_right = 30
-corner_radius_bottom_left = 30
 
 [node name="Control" type="Control"]
 layout_mode = 3
@@ -163,7 +163,7 @@ select_mode = 1
 allow_search = false
 item_count = 2
 same_column_width = true
-item_0/text = "Pistol - $200"
+item_0/text = "Pistol - $0"
 item_1/text = "Sniper Rifle - $500"
 
 [node name="Equipment List" type="ItemList" parent="."]
@@ -183,7 +183,7 @@ select_mode = 1
 allow_search = false
 item_count = 2
 same_column_width = true
-item_0/text = "Double Jump - $200"
+item_0/text = "Double Jump - $0"
 item_1/text = "Grapple Hook - $500"
 
 [node name="Label2" type="Label" parent="."]
@@ -223,6 +223,31 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_wsjs3")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_qqqpp")
 theme_override_styles/normal = SubResource("StyleBoxFlat_uktrp")
 text = "Confirm Selection"
+
+[node name="Bank" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -204.0
+offset_top = 6.0
+offset_right = -8.0
+offset_bottom = 70.0
+grow_horizontal = 0
+theme_override_font_sizes/font_size = 30
+theme_override_styles/normal = SubResource("StyleBoxFlat_nwf7w")
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Cart" type="Label" parent="."]
+layout_mode = 0
+offset_left = 463.0
+offset_top = 73.0
+offset_right = 596.0
+offset_bottom = 102.0
+theme_override_colors/font_color = Color(1, 0, 0, 1)
+theme_override_font_sizes/font_size = 20
+vertical_alignment = 1
 
 [node name="Select_Confirm" type="Control" parent="."]
 visible = false
@@ -394,29 +419,78 @@ Weapon And Equipment"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Bank" type="Label" parent="."]
+[node name="Not_Enough" type="Control" parent="."]
+visible = false
 layout_mode = 1
-anchors_preset = 1
-anchor_left = 1.0
+anchors_preset = 15
 anchor_right = 1.0
-offset_left = -204.0
-offset_top = 6.0
-offset_right = -8.0
-offset_bottom = 70.0
-grow_horizontal = 0
-theme_override_font_sizes/font_size = 30
-theme_override_styles/normal = SubResource("StyleBoxFlat_nwf7w")
-horizontal_alignment = 1
-vertical_alignment = 1
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="Cart" type="Label" parent="."]
-layout_mode = 0
-offset_left = 463.0
-offset_top = 73.0
-offset_right = 596.0
-offset_bottom = 102.0
-theme_override_colors/font_color = Color(1, 0, 0, 1)
+[node name="Panel2" type="Panel" parent="Not_Enough"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_5xvl3")
+
+[node name="Panel" type="Panel" parent="Not_Enough"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -159.5
+offset_top = -83.0
+offset_right = 159.5
+offset_bottom = 83.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_7dg0r")
+
+[node name="Okay2" type="Button" parent="Not_Enough"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -34.5
+offset_top = -173.0
+offset_right = 34.5
+offset_bottom = -131.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_styles/hover = SubResource("StyleBoxFlat_x4801")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_iw1oh")
+theme_override_styles/normal = SubResource("StyleBoxFlat_bcgog")
+text = "Okay
+"
+
+[node name="Label" type="Label" parent="Not_Enough"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -149.0
+offset_top = -63.0
+offset_right = 149.0
+offset_bottom = -17.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_font_sizes/font_size = 20
+text = "Insufficient Funds"
+horizontal_alignment = 1
 vertical_alignment = 1
 
 [connection signal="item_clicked" from="Weapons List" to="." method="_on_weapons_list_item_clicked"]
@@ -425,3 +499,4 @@ vertical_alignment = 1
 [connection signal="pressed" from="Select_Confirm/Yes" to="." method="_on_yes_pressed"]
 [connection signal="pressed" from="Select_Confirm/No" to="." method="_on_no_pressed"]
 [connection signal="pressed" from="Must_Select/Okay" to="." method="_on_okay_pressed"]
+[connection signal="pressed" from="Not_Enough/Okay2" to="." method="_on_okay_2_pressed"]

--- a/scenes/shop.tscn
+++ b/scenes/shop.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://bdq6vsxylm87t"]
+[gd_scene load_steps=12 format=3 uid="uid://bdq6vsxylm87t"]
 
 [ext_resource type="Script" path="res://scenes/shop.gd" id="1_2hesb"]
 
@@ -96,6 +96,19 @@ corner_radius_bottom_right = 30
 corner_radius_bottom_left = 30
 shadow_size = 3
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nwf7w"]
+bg_color = Color(0, 0, 0, 0.423529)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+border_blend = true
+corner_radius_top_left = 30
+corner_radius_top_right = 30
+corner_radius_bottom_right = 30
+corner_radius_bottom_left = 30
+
 [node name="Control" type="Control"]
 layout_mode = 3
 anchors_preset = 15
@@ -115,6 +128,7 @@ grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_hlxe3")
 
 [node name="Label" type="Label" parent="."]
+visible = false
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -139,19 +153,18 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -166.0
+offset_left = -202.0
 offset_top = -39.0
-offset_right = -32.0
+offset_right = -37.0
 offset_bottom = 60.0
 grow_horizontal = 2
 grow_vertical = 2
 select_mode = 1
 allow_search = false
-
 item_count = 2
 same_column_width = true
-item_0/text = "Pistol"
-item_1/text = "Sniper Rifle"
+item_0/text = "Pistol - $200"
+item_1/text = "Sniper Rifle - $500"
 
 [node name="Equipment List" type="ItemList" parent="."]
 layout_mode = 1
@@ -160,9 +173,9 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = 41.0
+offset_left = 34.0
 offset_top = -39.0
-offset_right = 175.0
+offset_right = 217.0
 offset_bottom = 60.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -170,22 +183,22 @@ select_mode = 1
 allow_search = false
 item_count = 2
 same_column_width = true
-item_0/text = "Double Jump"
-item_1/text = "Grapple Hook"
+item_0/text = "Double Jump - $200"
+item_1/text = "Grapple Hook - $500"
 
 [node name="Label2" type="Label" parent="."]
 layout_mode = 0
-offset_left = 182.0
+offset_left = 162.0
 offset_top = 110.0
-offset_right = 254.0
+offset_right = 234.0
 offset_bottom = 133.0
 text = "Weapons"
 
 [node name="Label3" type="Label" parent="."]
 layout_mode = 0
-offset_left = 383.0
+offset_left = 405.0
 offset_top = 110.0
-offset_right = 468.0
+offset_right = 490.0
 offset_bottom = 133.0
 text = "Equipment"
 
@@ -306,9 +319,109 @@ text = "Confirm Selection"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="Must_Select" type="Control" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Panel2" type="Panel" parent="Must_Select"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_5xvl3")
+
+[node name="Panel" type="Panel" parent="Must_Select"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -159.5
+offset_top = -83.0
+offset_right = 159.5
+offset_bottom = 83.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_7dg0r")
+
+[node name="Okay" type="Button" parent="Must_Select"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -34.5
+offset_top = -173.0
+offset_right = 34.5
+offset_bottom = -131.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_styles/hover = SubResource("StyleBoxFlat_x4801")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_iw1oh")
+theme_override_styles/normal = SubResource("StyleBoxFlat_bcgog")
+text = "Okay
+"
+
+[node name="Label" type="Label" parent="Must_Select"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -149.0
+offset_top = -63.0
+offset_right = 149.0
+offset_bottom = -17.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 20
+text = "Must Select
+Weapon And Equipment"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Bank" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -204.0
+offset_top = 6.0
+offset_right = -8.0
+offset_bottom = 70.0
+grow_horizontal = 0
+theme_override_font_sizes/font_size = 30
+theme_override_styles/normal = SubResource("StyleBoxFlat_nwf7w")
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Cart" type="Label" parent="."]
+layout_mode = 0
+offset_left = 463.0
+offset_top = 73.0
+offset_right = 596.0
+offset_bottom = 102.0
+theme_override_colors/font_color = Color(1, 0, 0, 1)
+theme_override_font_sizes/font_size = 20
+vertical_alignment = 1
+
 [connection signal="item_clicked" from="Weapons List" to="." method="_on_weapons_list_item_clicked"]
 [connection signal="item_clicked" from="Equipment List" to="." method="_on_equipment_list_item_clicked"]
-
 [connection signal="pressed" from="Confirm" to="." method="_on_confirm_pressed"]
 [connection signal="pressed" from="Select_Confirm/Yes" to="." method="_on_yes_pressed"]
 [connection signal="pressed" from="Select_Confirm/No" to="." method="_on_no_pressed"]
+[connection signal="pressed" from="Must_Select/Okay" to="." method="_on_okay_pressed"]


### PR DESCRIPTION
- Variables to track held and stored currency 
- Assigned costs to weapon and equipment items 
- Shop displays player's currency and total cost of items selected 
- Timer rewards player with $5 per second as long as they are alive 
- Checks if a player has selected a weapon and equipment item before entering the level

- Adds a game over screen to the game that gives the player the option to quit the game or restart
- Made some changes to the shop to accommodate the addition of a restart mechanic
- Made it so you can't spend more money at the shop than you have in your bank
- Added a death function to the player script
Note that the only thing that can currently kill the player is the bullets from the flying boss. I purposefully overturned the damage of each bullet to make testing easier.